### PR TITLE
Change codepoints to avoid conflict with draft revisions

### DIFF
--- a/draft-iyengar-quic-delayed-ack.md
+++ b/draft-iyengar-quic-delayed-ack.md
@@ -169,7 +169,7 @@ signals its tolerance to its peer using an ACK_FREQUENCY frame, shown below:
  0                   1                   2                   3
  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                            0xff02af (i)                     ...
+|                            0xaf (i)                         ...
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |                      Sequence Number (i)                    ...
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
@@ -182,8 +182,8 @@ signals its tolerance to its peer using an ACK_FREQUENCY frame, shown below:
 ~~~
 
 Following the common frame format described in Section 12.4 of
-{{QUIC-TRANSPORT}}, ACK_FREQUENCY frames have a type of 0xff02af, and contain
-the following fields:
+{{QUIC-TRANSPORT}}, ACK_FREQUENCY frames have a type of 0xaf, and contain the
+following fields:
 
 Sequence Number:
 

--- a/draft-iyengar-quic-delayed-ack.md
+++ b/draft-iyengar-quic-delayed-ack.md
@@ -142,7 +142,7 @@ mechanism to solve this problem.
 Endpoints advertise their support of the extension described in this document by
 sending the following transport parameter (Section 7.2 of {{QUIC-TRANSPORT}}):
 
-min_ack_delay (0xDE1A):
+min_ack_delay (0xff02de1a):
 
 : A variable-length integer representing the minimum amount of time in
   microseconds by which the endpoint can delay an acknowledgement. Values of
@@ -169,7 +169,7 @@ signals its tolerance to its peer using an ACK_FREQUENCY frame, shown below:
  0                   1                   2                   3
  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                            0xAF (i)                         ...
+|                            0xff02af (i)                     ...
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |                      Sequence Number (i)                    ...
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
@@ -182,8 +182,8 @@ signals its tolerance to its peer using an ACK_FREQUENCY frame, shown below:
 ~~~
 
 Following the common frame format described in Section 12.4 of
-{{QUIC-TRANSPORT}}, ACK_FREQUENCY frames have a type of 0xAF, and contain the
-following fields:
+{{QUIC-TRANSPORT}}, ACK_FREQUENCY frames have a type of 0xff02af, and contain
+the following fields:
 
 Sequence Number:
 


### PR DESCRIPTION
We don't need to change the frame type on each draft version, but I figured that it'd be safer.