### PR TITLE
min_ack_delay is a unilateral indication

### DIFF
--- a/draft-iyengar-quic-delayed-ack.md
+++ b/draft-iyengar-quic-delayed-ack.md
@@ -158,7 +158,7 @@ min_ack_delay is specified in microseconds.
 
 The min_ack_delay transport parameter is a unilateral indication of support for
 receiving ACK_FREQUENCY frames.  The transport parameter is not required to be
-sent by both endpoints.  If an endpoint sends the transport parameter the peer
+sent by both endpoints.  If an endpoint sends the transport parameter, the peer
 is allowed to send ACK_FREQUENCY frames independent of whether it also sends
 the min_ack_delay transport parameter or not.
 

--- a/draft-iyengar-quic-delayed-ack.md
+++ b/draft-iyengar-quic-delayed-ack.md
@@ -157,10 +157,9 @@ transport parameter is in milliseconds (Section 18.2 of {{QUIC-TRANSPORT}}),
 min_ack_delay is specified in microseconds.
 
 The min_ack_delay transport parameter is a unilateral indication of support for
-receiving ACK_FREQUENCY frames.  The transport parameter is not required to be
-sent by both endpoints.  If an endpoint sends the transport parameter, the peer
-is allowed to send ACK_FREQUENCY frames independent of whether it also sends
-the min_ack_delay transport parameter or not.
+receiving ACK_FREQUENCY frames.  If an endpoint sends the transport parameter,
+the peer is allowed to send ACK_FREQUENCY frames independent of whether it also
+sends the min_ack_delay transport parameter or not.
 
 This Transport Parameter is encoded as per Section 18 of {{QUIC-TRANSPORT}}.
 

--- a/draft-iyengar-quic-delayed-ack.md
+++ b/draft-iyengar-quic-delayed-ack.md
@@ -156,6 +156,12 @@ TRANSPORT_PARAMETER_ERROR. Note that while the endpoint's max_ack_delay
 transport parameter is in milliseconds (Section 18.2 of {{QUIC-TRANSPORT}}),
 min_ack_delay is specified in microseconds.
 
+The min_ack_delay transport parameter is a unilateral indication of support for
+receiving ACK_FREQUENCY frames.  The transport parameter is not required to be
+sent by both endpoints.  If an endpoint sends the transport parameter the peer
+is allowed to send ACK_FREQUENCY frames independent of whether it also sends
+the min_ack_delay transport parameter or not.
+
 This Transport Parameter is encoded as per Section 18 of {{QUIC-TRANSPORT}}.
 
 # ACK_FREQUENCY Frame


### PR DESCRIPTION
Fixes #42. Clearly declares that the TP only works in one direction.