### PR TITLE
Apply 1/2 of  a change that was lost

### DIFF
--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -146,7 +146,9 @@ sending the following transport parameter ({{Section 7.2 of QUIC-TRANSPORT}}):
 min_ack_delay (0xff03de1a):
 
 : A variable-length integer representing the minimum amount of time in
-  microseconds by which the endpoint can delay an acknowledgement.
+  microseconds by which the endpoint can delay an acknowledgement. Values of
+  2^24 or greater are invalid, and receipt of these values MUST be treated as
+  a connection error of type TRANSPORT_PARAMETER_ERROR.
 
 An endpoint's min_ack_delay MUST NOT be greater than its max_ack_delay.
 Endpoints that support this extension MUST treat receipt of a min_ack_delay that


### PR DESCRIPTION
@rpaulo posted that this change was missed.  This pulls in the first part, and I think the second part has been superceded.

https://github.com/quicwg/ack-frequency/commit/8a87dbd3d38c40507a2ca346f242fbdee3866ec3

Fixes #90 