### PR TITLE
Fix whitespace problems from 956f88fd.

### DIFF
--- a/draft-ietf-quic-ack-frequency.md
+++ b/draft-ietf-quic-ack-frequency.md
@@ -223,7 +223,7 @@ Ignore Order:
 : An 8-bit field representing a boolean truth value. This field is
   set to `true` by an endpoint that does not wish to receive an immediate
   acknowledgement when the peer observes reordering ({{reordering}}).
-  The value of this field MUST be 0x00 (representing `false`) or 0x01 
+  The value of this field MUST be 0x00 (representing `false`) or 0x01
   (representing `true`).  Receipt of any other value MUST be treated
   as a connection error of type FRAME_ENCODING_ERROR.
 


### PR DESCRIPTION
```
227:  The value of this field MUST be 0x00 (representing `false`) or 0x01 
draft-ietf-quic-ack-frequency.md contains trailing whitespace
```